### PR TITLE
Enhance hero section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,15 @@
         </div>
     </nav>
     <header class="hero">
-        <div class="container">
-            <h1>Your AI Coach is Here</h1>
-            <p>Joga AI watches your game. Then it coaches you.</p>
-            <a href="#waitlist" class="cta">Join the Beta</a>
+        <div class="container hero-content">
+            <div class="hero-text">
+                <h1>Your AI Coach is Here</h1>
+                <p>Joga AI watches your game. Then it coaches you.</p>
+                <a href="#waitlist" class="cta">Join the Beta</a>
+            </div>
+            <div class="hero-image">
+                <img src="images/Joga.png" alt="Joga AI logo">
+            </div>
         </div>
     </header>
 

--- a/styles.css
+++ b/styles.css
@@ -6,7 +6,34 @@ body {
   scroll-behavior: smooth;
 }
 .container { width: 90%; max-width: 1000px; margin: 0 auto; padding: 2rem 0; }
-.hero { background: linear-gradient(135deg,#1a1a1a,#333); color: #fff; text-align: center; padding: 6rem 0; }
+.hero {
+  background: linear-gradient(135deg, #1e3c72, #2a5298);
+  color: #fff;
+  padding: 6rem 0;
+}
+.hero-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+.hero-text {
+  flex: 1 1 300px;
+  text-align: left;
+  opacity: 0;
+  animation: fadeIn 1s ease forwards;
+}
+.hero-image {
+  flex: 1 1 300px;
+  text-align: center;
+}
+.hero-image img {
+  max-width: 100%;
+  height: auto;
+  opacity: 0;
+  animation: slideIn 1s ease forwards;
+}
 .hero h1 { font-size: 3rem; margin-bottom: 1rem; }
 .hero p { font-size: 1.2rem; margin-bottom: 2rem; }
 .cta { background: #fff; color: #000; padding: 0.8rem 2rem; border-radius: 4px; text-decoration: none; font-weight: bold; }
@@ -90,4 +117,34 @@ body {
   }
   .nav-links.open { max-height: 300px; }
   .hamburger { display: block; }
+
+  .hero-content {
+    flex-direction: column;
+  }
+  .hero-text,
+  .hero-image {
+    text-align: center;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(50px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
 }


### PR DESCRIPTION
## Summary
- add side-by-side hero layout with image
- animate hero text and image
- improve hero background and responsiveness

## Testing
- `bash -c '[ -f images/Joga.png ] && echo exists'`


------
https://chatgpt.com/codex/tasks/task_e_6869133d8408832db17924bf107ed1ef